### PR TITLE
println doesn't print the output on the next line issue has been fixed

### DIFF
--- a/src/pages/EditorComponent.js
+++ b/src/pages/EditorComponent.js
@@ -23,7 +23,7 @@ const StyledButton = styled(Button)({
 
 function EditorComponent() {
   const [code, setCode] = useState(null);
-  const [output, setOutput] = useState("");
+  const [output, setOutput] = useState([]);
   const [currentLanguage, setCurrentLanguage] = useState(
     LANGUAGES[0].DEFAULT_LANGUAGE,
   );
@@ -108,7 +108,8 @@ function EditorComponent() {
               setOutput(data.message);
               return;
             }
-            setOutput(data.stdout);
+            const formatedData = data.stdout.split("\n")
+            setOutput(formatedData);
           })
           .catch((error) => {
             enqueueSnackbar("Error retrieving output: " + error.message, {
@@ -169,7 +170,13 @@ function EditorComponent() {
           </StyledButton>
         </div>
       </div>
-      <div className="output">{output}</div>
+      <div className="output">
+        {
+          output && output.map((result, i)=>{
+            return <div key={i}>{result}</div>
+          })
+        }
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Resolves #[85] 
### PR Fixes:
- 1 Added fix that will print the code result on next line.

### Checklist before requesting a review
- [x] I have pull latest changes from `main` branch
- [x] I have tested the changes locally
- [x] I have run `npm run lint:fix` locally
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue


PFB the working solution
[issue fixed.webm](https://github.com/user-attachments/assets/50bfb08a-6bb5-4305-853e-adf92840501c)
