### PR TITLE
Click action on Star on Github CTA should redirect user to github repo issue has been fixed

### DIFF
--- a/src/components/js/Stars.js
+++ b/src/components/js/Stars.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { FaStar, FaGithub } from "react-icons/fa";
 import CircularLoading from "./CircularLoading";
 import { useGetStars } from "../../hooks/useGetStars";
@@ -19,18 +20,20 @@ const Stars = () => {
     );
 
   return (
-    <div style={styles.starsCon}>
-      <div style={styles.stars}>
-        <FaGithub fontSize={32} />
-        <div style={styles.starsCount}>
-          <span>Star on GitHub</span>
-          <span style={{ color: "gold" }}>
-            {repositoryStarts} {repositoryStarts > 1 ? "stars" : "star"}{" "}
-            <FaStar style={styles.star} color='gold' />
-          </span>
+    <Link to="https://github.com/DhanushNehru/CustomCodeEditor" target="_blank" style={styles.githubLink}>
+      <div style={styles.starsCon}>
+        <div style={styles.stars}>
+          <FaGithub fontSize={32} />
+          <div style={styles.starsCount}>
+            <span>Star on GitHub</span>
+            <span style={{ color: "gold" }}>
+              {repositoryStarts} {repositoryStarts > 1 ? "stars" : "star"}{" "}
+              <FaStar style={styles.star} color='gold' />
+            </span>
+          </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 };
 
@@ -71,4 +74,8 @@ const styles = {
     borderRadius: "5px",
     cursor: "pointer",
   },
+  githubLink: {
+    textDecoration: "none",
+    color: "inherit"
+  }
 };


### PR DESCRIPTION
Resolves #[87] 
### PR Fixes:
- 1 Added link so that whenever the user clicks on GitHub star, it should redirect the user to GitHub repo.

### Checklist before requesting a review
- [x] I have pull latest changes from `main` branch
- [x] I have tested the changes locally
- [x] I have run `npm run lint:fix` locally
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue

Demo:-

https://github.com/user-attachments/assets/3ab942bf-93bf-4b45-ace4-c2be23d5cccd


