### PR TITLE
fix: Unable to type in editor

### DIFF
--- a/src/pages/EditorComponent.js
+++ b/src/pages/EditorComponent.js
@@ -23,6 +23,31 @@ const StyledButton = styled(Button)({
   gap: "0.5rem",
 });
 
+
+const StyledLayout = styled("div")(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
+  marginLeft: "0.5rem",
+  marginRight: "0.5rem",
+  padding: "0.5rem",
+  border: `3px solid ${theme.palette.divider}`,
+  borderRadius: "1rem",
+  "@media (min-width: 768px)": {
+    flexDirection: "row",
+  },
+}));
+
+const OutputLayout = styled("div")(({ theme }) => ({
+  backgroundColor: theme.palette.background.paper,
+  height: "22.3vh",
+  overflowY: "auto",
+  padding: "1rem",
+  margin: "0.5rem",
+  border: `3px solid ${theme.palette.divider}`,
+  borderRadius: "1rem",
+}));
+
 function EditorComponent() {
   const [code, setCode] = useState(null);
   const [output, setOutput] = useState([]);
@@ -34,29 +59,6 @@ function EditorComponent() {
   const { enqueueSnackbar } = useSnackbar();
   const editorRef = useRef(null);
 
-  const StyledLayout = styled("div")(({ theme }) => ({
-    display: "flex",
-    flexDirection: "column",
-    height: "100%",
-    marginLeft: "0.5rem",
-    marginRight: "0.5rem",
-    padding: "0.5rem",
-    border: `3px solid ${theme.palette.divider}`,
-    borderRadius: "1rem",
-    "@media (min-width: 768px)": {
-      flexDirection: "row",
-    },
-  }));
-
-  const OutputLayout = styled("div")(({ theme }) => ({
-    backgroundColor: theme.palette.background.paper,
-    height: "22.3vh",
-    overflowY: "auto",
-    padding: "1rem",
-    margin: "0.5rem",
-    border: `3px solid ${theme.palette.divider}`,
-    borderRadius: "1rem",
-  }));
 
   const styles = {
     flex: {


### PR DESCRIPTION
**Submitting for Hacktoberfest'24**
As a part of PR #101, declaring `styled` style components within functions lead to unnecessary re-renders, hindering the typing experience. Moving the layout definition outside the function to fix typing issue.

### Checklist before requesting a review
- [x] I have pull latest changes from `main` branch
- [x] I have tested the changes locally
- [x] I have run `npm run lint:fix` locally
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
