### PR TITLE
fix: github login button visibility in light/dark mode

### DIFF
--- a/src/components/GithubSignIn.js
+++ b/src/components/GithubSignIn.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import "../components/css/GithubSignIn.css";
+import { Button } from "@mui/material";
 import { useAuth } from "../context/AuthContext.js";
 
 const GithubSignIn = () => {
@@ -23,15 +23,30 @@ const GithubSignIn = () => {
   };
 
   return loading ? null : (
-    <button onClick={handleSignIn} className="github-sign-in-button">
+    <Button
+      variant="outlined"
+      onClick={handleSignIn}
+      sx={[
+        (theme) => ({
+          marginLeft: "5px",
+          bgcolor: theme.palette.text.primary,
+          color: theme.palette.background.default,
+          border: "1px solid #E2E8F0",
+          fontSize: "0.8em",
+          cursor: "pointer",
+          boxShadow: "0 4px 6px rgba(0, 0, 0, 0.1)",
+        }),
+      ]}
+    >
       <img
         className="github-logo"
+        style={{ height: "25px", width: "25px", paddingRight: "6px" }}
         src="https://www.svgrepo.com/show/452211/github.svg"
         loading="lazy"
         alt="github logo"
       />
       <span>Login with Github</span>
-    </button>
+    </Button>
   );
 };
 


### PR DESCRIPTION
Fixes GitHub login button visibility in light/dark mode.

### Checklist before requesting a review
- [x] I have pull latest changes from `main` branch
- [x] I have tested the changes locally
- [x] I have run `npm run lint:fix` locally
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
