### PR TITLE
fix: prevent output overflow in output box for large loops (#196)

### DIFF
--- a/src/pages/EditorComponent.js
+++ b/src/pages/EditorComponent.js
@@ -50,6 +50,7 @@ const OutputLayout = styled("div")(({ theme }) => ({
   backgroundColor: theme.palette.background.paper,
   height: "50vh",
   margin: "1rem 0",
+  overflow: "auto",
   border: `2px solid ${theme.palette.divider}`,
   borderRadius: "1rem",
   "@media (min-width: 1024px)": {


### PR DESCRIPTION
Resolves #196 
### PR Fixes:
- This PR fixes the bug causing output from large loops to overflow beyond the visible output box by ensuring the output area remains scrollable

<img width="1918" height="942" alt="image" src="https://github.com/user-attachments/assets/3ac76958-bfd7-4a39-9d0f-f8e8812101a2" />


### Checklist before requesting a review
- [x] I have pull latest changes from `main` branch
- [x] I have tested the changes locally
- [x] I have run `npm run lint:fix` locally
- [x] I have performed a self-review of my code
- [x] I assure there is no similar/duplicate pull request regarding same issue
